### PR TITLE
Use torch.max instead of torch.nn.MaxPool1d

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -8,7 +8,6 @@ import torch
 import json
 import codecs
 import numpy as np
-import progressbar
 import sys
 import torchvision.transforms as transforms
 import argparse


### PR DESCRIPTION
According to the original paper, there should be no restriction on the number of points within a point cloud. This PR updates the pointnet to allow for variable number of points within a pointcloud or from mini-batch to mini-batch.

If one has a dataset that has different numbers of points within each point cloud, one way of using this is to upsample (similar to how images are padded with 0s when they are different sizes). However, one wants to minimize the number of added points because unlike image data, adding 0s in a point cloud changes the structure of the data. Instead, one should duplicate the fewest number of points such that each sample in a mini-batch has the same number of points but each mini-batch may have a different number of points per sample.

To do this, one should sort their dataset by the number of points within each point cloud, then group the point clouds into sizes of the desired mini-batch. For example one mini-batch may have point clouds of sizes: `[901, 905, 905, ..., 945]`.
In order to upsample all pointclouds `P` in `mini-batch_j`, one randomly duplicates `K` points from a pointcloud `P_i` with `N` points where `K` is the difference between the current pointcloud size and the maximum pointcloud size in `mini-batch_j` (`K = max(P_i.size() for P_i in mini-batch_j) - N`).

For example, the previous example, the mini-batch will now have sizes `[945, 945, 945, ..., 945]` because the first pointcloud with size `901` had (`945 - 901`) `44` points duplicated, etc. Now that each mini-batch has the same number of points, one can train their network by randomly sampling these mini-batches.